### PR TITLE
Import (deprecated) imp library

### DIFF
--- a/pypreprocessor/__init__.py
+++ b/pypreprocessor/__init__.py
@@ -8,6 +8,7 @@ __version__ = '0.7.7'
 import sys
 import os
 import traceback
+import imp
 import importlib
 import io
 class preprocessor:


### PR DESCRIPTION
`__init__.py` still uses `imp.lock_held()`, which requires the `imp` library.